### PR TITLE
fix: 代理设置无效

### DIFF
--- a/models/utils/request.js
+++ b/models/utils/request.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { Config } from '#components'
-import { ProxyAgent } from 'proxy-agent'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 
 /**
  * 通用请求方法
@@ -14,7 +15,8 @@ export default async function request (url, options = {}) {
   return await axios.request({
     url,
     baseURL,
-    httpAgent: Config.steam.proxy ? new ProxyAgent(Config.steam.proxy) : undefined,
+    httpAgent: Config.steam.proxy ? new HttpProxyAgent(Config.steam.proxy) : undefined,
+    httpsAgent: Config.steam.proxy ? new HttpsProxyAgent(Config.steam.proxy) : undefined,
     ...options,
     params: {
       key: baseURL === steamApi ? Config.steam.apiKey : undefined,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "chalk": "^5.3.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "proxy-agent": "^6.4.0",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.5",
     "sequelize": "^6.37.5",
     "sqlite3": "5.1.6"
   },


### PR DESCRIPTION
实测在锅巴内配置 `proxy代理` 为形式如 `http://ip:端口` 时，没有通过代理直接发送了请求。如此配置测试可以通过代理发送请求。

TRSS-Yunzai 3.13
arch wsl
node v22.9.0
proxy-agent 6.4.0