### PR TITLE
style: 优化 #steam库存 图片渲染样式，防止图片过大文字过小捏

### DIFF
--- a/resources/inventory/image.css
+++ b/resources/inventory/image.css
@@ -19,29 +19,30 @@ body {
 }
 
 .user-info h1 {
-    font-size: 34px;
-    margin-bottom: 3px;
+    font-size: 80px;
+    margin-bottom: 15px;
     color: #2b303b;
     text-shadow: 1px 1px 1px #000;
 }
 
 .stats {
     display: flex;
-    gap: 15px;
-    font-size: 26px;
+    gap: 30px;
+    font-size: 48px;
     color: #aaa;
     text-shadow: 1px 1px 1px #000;
 }
 
 .tip {
     color: #d3d3d3;
-    font-size: 22px;
+    font-size: 36px;
     text-shadow: 1px 1px 1px #000;
 }
 
 .header {
     display: flex;
-    padding-left: 15px;
+    padding: 40px 60px;
+    align-items: center;
 }
 
 .content {
@@ -56,6 +57,8 @@ body {
 }
 
 .avatar img {
+    width: 300px;
+    height: 300px;
     border-radius: 50%;
 }
 


### PR DESCRIPTION
# PR Title
style: 优化 #steam库存 图片渲染样式

# PR Description
## 修改内容
- 调大了 `#steam库存` 渲染图片顶部的文字大小（用户名、统计信息、提示语）。
- 固定了头像显示尺寸为 300x300px，避免因原图尺寸导致布局比例失调。
- 优化了 Header 区域的内边距和对齐方式。

## 解决问题
修复了在 1920px 宽度下，右上角文字过小、难以阅读的问题。


> 原先的效果：
<img width="620" height="1193" alt="25caf6e7f485169c8d61d607c3fb9d28" src="https://github.com/user-attachments/assets/503c57d8-60d2-4092-b16c-e1ee82f200ac" />

> 现在的效果:
![12b923de16d0e22154740c1b1c98f05f](https://github.com/user-attachments/assets/1d8e6cb4-57ba-4718-b41a-005f3f8bec46)

